### PR TITLE
feat: propagate storage error

### DIFF
--- a/.eslintcache
+++ b/.eslintcache
@@ -1,1 +1,0 @@
-[{"/Users/apollo/works/crypto/torus/clone26/tss-server/packages/tss-lib/node.js":"1","/Users/apollo/works/crypto/torus/clone26/tss-server/packages/tss-lib/wasm/serverWasm.js":"2"},{"size":23516,"mtime":1700625303161},{"size":895687,"mtime":1700625040092}]

--- a/src/Bridge.tsx
+++ b/src/Bridge.tsx
@@ -117,11 +117,11 @@ export const Bridge = (params: { logLevel?: LogLevelDesc; resolveReady: (value: 
     }
 
     if (message.type === "error") {
-      const { payload, error } = message.data as LibError;
+      const { payload } = message.data as LibError;
       if (payload.ruid && payload.action) {
-        handleTssLibError( {...payload as MessageResponse});
+        handleTssLibError({ ...(payload as MessageResponse) });
       } else {
-        log.error('error',  payload.error);
+        log.error("error", payload.error);
       }
     }
     if (message.type === "state") {

--- a/src/Bridge.tsx
+++ b/src/Bridge.tsx
@@ -119,9 +119,9 @@ export const Bridge = (params: { logLevel?: LogLevelDesc; resolveReady: (value: 
     if (message.type === "error") {
       const { payload, error } = message.data as LibError;
       if (payload.ruid && payload.action) {
-        handleTssLibError({ ...(payload as MessageResponse), error });
+        handleTssLibError( {...payload as MessageResponse});
       } else {
-        log.error("error", error);
+        log.error('error',  payload.error);
       }
     }
     if (message.type === "state") {

--- a/src/WebApp/index.tsx
+++ b/src/WebApp/index.tsx
@@ -82,30 +82,30 @@ const createStorageInstance = (tag: string) => {
   return memoryStorage;
 };
 
-async function handleResponse(data: MessageResponse): Promise<MessageResponse> {
+async function handleResponse(data: MessageResponse): Promise<void> {
   const { action, result, ruid, error: msgerror } = data;
   if (msgerror) {
     resolverMap.delete(ruid);
     rejectMap.get(ruid)(msgerror);
     rejectMap.delete(ruid);
-    return { ruid, action, result: "done" };
+    return;
   }
 
   if (action === StorageAction.getItem) {
     rejectMap.delete(ruid);
     resolverMap.get(ruid)(result);
     resolverMap.delete(ruid);
-    return { ruid, action, result: "done" };
+    return;
   }
 
   if (action === StorageAction.setItem) {
     rejectMap.delete(ruid);
     resolverMap.get(ruid)(result);
     resolverMap.delete(ruid);
-    return { ruid, action, result: "done" };
+    return;
   }
 
-  return { ruid, action, result: "done" };
+  throw Error(`unknown action type - ${action} \n ruid - ${ruid}`);
 }
 
 const corekitInstanceMap = new Map<string, Web3AuthMPCCoreKit>();
@@ -139,7 +139,7 @@ const Root = () => {
       try {
         await handleResponse(message.data);
       } catch (e) {
-        debug({ type: `handleTssLibResponse error - ${message.data?.action}`, e });
+        debug({ type: `handleResponse error - ${message.data?.action}`, e });
         error({
           msg: `${message.type} error`,
           payload: message.data,

--- a/src/WebApp/index.tsx
+++ b/src/WebApp/index.tsx
@@ -88,7 +88,7 @@ async function handleResponse(data: MessageResponse): Promise<MessageResponse> {
     resolverMap.delete(ruid);
     rejectMap.get(ruid)(msgerror);
     rejectMap.delete(ruid);
-    return { ruid, action, result: 'done' };
+    return { ruid, action, result: "done" };
   }
 
   if (action === StorageAction.getItem) {
@@ -97,7 +97,7 @@ async function handleResponse(data: MessageResponse): Promise<MessageResponse> {
     resolverMap.delete(ruid);
     return { ruid, action, result: "done" };
   }
-  
+
   if (action === StorageAction.setItem) {
     rejectMap.delete(ruid);
     resolverMap.get(ruid)(result);
@@ -139,7 +139,7 @@ const Root = () => {
       try {
         await handleResponse(message.data);
       } catch (e) {
-        debug({ type: 'handleTssLibResponse error - ' + message.data?.action , e });
+        debug({ type: `handleTssLibResponse error - ${message.data?.action}`, e });
         error({
           msg: `${message.type} error`,
           payload: message.data,
@@ -174,7 +174,7 @@ const Root = () => {
         }
         emit({ type: BrigeToRNMessageType.CoreKitResponse, data: result });
       } catch (e) {
-        debug({ type: 'error - ' + message.data?.action , e });
+        debug({ type: `error - ${message.data?.action}`, e });
         error({
           msg: `${message.type} error`,
           payload: message.data,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. When there is storage error, sdk only log the error causing the function that call storage function hang
2.rejectMap request is not removed after response from storage

Jira Link:


## Description
<!--- Describe your changes in detail -->
reject storage request when there is error from storage.
remove resolveMap and rejectMap on completion


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
